### PR TITLE
default offset null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 before_install:
-- wget https://releases.hashicorp.com/terraform/0.5.3/terraform_0.5.3linux_amd64.zip
+- wget https://releases.hashicorp.com/terraform/0.5.3/terraform_0.5.3_linux_amd64.zip
   -O /tmp/terraform.zip
 - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,3 @@ before_install:
   -O /tmp/terraform.zip
 - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
 script: make test
-env:
-  global:
-  - secure: PP4gidLUq+6LCCykRu+CFUu4ed/FYbqJ1JVUDnd99jPiPJMvBS18CFLh5zu+edrL7rRmOJVGDIBbtbRzxXQk4jtYcAMlRaC8xjpBeHQ7Q7uN9LV+oMjptkt9QuH8D/jdjyRv5Eo/lIQFT386dqYN+PiowxoM1XL7i//5rp0H+Kc=
-  - secure: Nznz/tdKVWH8zkFX+veQ4RUonfpU4mWErrND7Ce9lqDeVnwMuVb/u8RVlTF523d5uOHRv0L1XdFP3TaMkRqOwocRU3oHuOZW/wDlqu0ONBFS0kjJvrIkibe6Ju/+j9RJMSUXQgDz1wQC8ZtuZoXAoSZgN3xsa/fym8Ze7+VbFVI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 before_install:
-- wget https://releases.hashicorp.com/terraform/0.5.3/terraform_0.5.3_linux_amd64.zip
+- wget https://releases.hashicorp.com/terraform/0.6.15/terraform_0.6.15_linux_amd64.zip
   -O /tmp/terraform.zip
 - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
 before_install:
-  - wget https://dl.bintray.com/mitchellh/terraform/terraform_0.5.0_linux_amd64.zip -O /tmp/terraform.zip
+  - wget https://releases.hashicorp.com/terraform/0.6.15/terraform_0.6.15_linux_amd64.zip -O /tmp/terraform.zip
   - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: c
 before_install:
-  - wget https://releases.hashicorp.com/terraform/0.6.15/terraform_0.6.15_linux_amd64.zip -O /tmp/terraform.zip
-  - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
+- wget https://releases.hashicorp.com/terraform/0.6.15/terraform_0.6.15_linux_amd64.zip
+  -O /tmp/terraform.zip
+- sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
 script: make test
+env:
+  global:
+  - secure: PP4gidLUq+6LCCykRu+CFUu4ed/FYbqJ1JVUDnd99jPiPJMvBS18CFLh5zu+edrL7rRmOJVGDIBbtbRzxXQk4jtYcAMlRaC8xjpBeHQ7Q7uN9LV+oMjptkt9QuH8D/jdjyRv5Eo/lIQFT386dqYN+PiowxoM1XL7i//5rp0H+Kc=
+  - secure: Nznz/tdKVWH8zkFX+veQ4RUonfpU4mWErrND7Ce9lqDeVnwMuVb/u8RVlTF523d5uOHRv0L1XdFP3TaMkRqOwocRU3oHuOZW/wDlqu0ONBFS0kjJvrIkibe6Ju/+j9RJMSUXQgDz1wQC8ZtuZoXAoSZgN3xsa/fym8Ze7+VbFVI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 before_install:
-- wget https://releases.hashicorp.com/terraform/0.6.15/terraform_0.6.15_linux_amd64.zip
+- wget https://releases.hashicorp.com/terraform/0.5.3/terraform_0.5.3linux_amd64.zip
   -O /tmp/terraform.zip
 - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
 script: make test

--- a/scripts/testPlan
+++ b/scripts/testPlan
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 exitcode=0
 TFILE=`mktemp -t terraform-aws-cf-net.XXX`
 GREEN="\e[1;34m"
@@ -35,7 +33,7 @@ OUTPUT=$(TF_VAR_aws_access_key=${TRAVIS_aws_access_key} TF_VAR_aws_secret_key=${
 CLEANUP "$?" "$desc" "$OUTPUT"
 
 desc="Did the baseline terraform plan change?"
-terraform plan -var-file terraform.tfvars.example &> $TFILE
+TF_VAR_aws_access_key=${TRAVIS_aws_access_key} TF_VAR_aws_secret_key=${TRAVIS_aws_secret_key} TF_VAR_aws_internet_gateway_id="X" TF_VAR_aws_key_name="bosh" TF_VAR_aws_key_path="~/.ssh/bosh.pem" TF_VAR_aws_route_table_private_id="X" TF_VAR_aws_route_table_public_id="X" TF_VAR_aws_vpc_id="X" terraform plan &> $TFILE
 OUTPUT=$(diff test-fixtures/terraform.testplan $TFILE)
 CLEANUP "$?" "$desc" "$OUTPUT"
 

--- a/scripts/testPlan
+++ b/scripts/testPlan
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 exitcode=0
 TFILE=`mktemp -t terraform-aws-cf-net.XXX`
 GREEN="\e[1;34m"

--- a/scripts/testPlan
+++ b/scripts/testPlan
@@ -29,7 +29,7 @@ OUTPUT=$(terraform get -update)
 CLEANUP "$?" "$desc" "Unable to fetch the modules we depend on"
 
 desc="Does the plan compile?"
-OUTPUT=$(terraform plan -var-file terraform.tfvars.example)
+OUTPUT=$(TF_VAR_aws_access_key=${TRAVIS_aws_access_key} TF_VAR_aws_secret_key=${TRAVIS_aws_secret_key} terraform plan -var-file terraform.tfvars.example)
 CLEANUP "$?" "$desc" "$OUTPUT"
 
 desc="Did the baseline terraform plan change?"

--- a/scripts/testPlan
+++ b/scripts/testPlan
@@ -31,7 +31,7 @@ OUTPUT=$(terraform get -update)
 CLEANUP "$?" "$desc" "Unable to fetch the modules we depend on"
 
 desc="Does the plan compile?"
-OUTPUT=$(TF_VAR_aws_access_key=${TRAVIS_aws_access_key} TF_VAR_aws_secret_key=${TRAVIS_aws_secret_key} terraform plan -var-file terraform.tfvars.example)
+OUTPUT=$(TF_VAR_aws_access_key=${TRAVIS_aws_access_key} TF_VAR_aws_secret_key=${TRAVIS_aws_secret_key} TF_VAR_aws_internet_gateway_id="X" TF_VAR_aws_key_name="bosh" TF_VAR_aws_key_path="~/.ssh/bosh.pem" TF_VAR_aws_route_table_private_id="X" TF_VAR_aws_route_table_public_id="X" TF_VAR_aws_vpc_id="X" terraform plan)
 CLEANUP "$?" "$desc" "$OUTPUT"
 
 desc="Did the baseline terraform plan change?"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,5 @@
-aws_access_key = $AWS_ACCESS_KEY
-aws_secret_key = $AWS_SECRET_KEY
+aws_access_key = "${AWS_ACCESS_KEY_ID}"
+aws_secret_key = "${AWS_SECRET_ACCESS_KEY}"
 aws_key_path = "~/.ssh/bosh.pem"
 aws_key_name = "bosh"
 aws_region = "us-east-1"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,5 @@
-aws_access_key = "F2j8zeb+vFAsHRZPArBIml12JOariFRXrGge88b2UpU0J128/No4VBvPyVSAEedjDOml/a8dE4ZKtZP09MRYk9a23a/t1TbW+IvYf3Ia0jvwBgbUtt8/TFd6n1aUHpP/+Oc/PlhklzHOGfm6ZT5F2lmyFrfvAcxnl3Ru+xghHGY="
-aws_secret_key = "euK9xBIMpCnD5r/5V76EJI2lCk5EbGhyUhFKFHOnMzXPSIEUbo7i7DW5oAJu5F0T/ynlhX68VUpUFJEz2QGs7CnqtOvHzl8763UFNisTbzCB7qXXQHIbLPKR+9lpxmeydL7o+3C5YIWk7hhRfQyxKaeLiWpXzOKCsJn8kT8EQY4="
+aws_access_key = "${AWS_ACCESS_KEY}"
+aws_secret_key = "${AWS_SECRET_KEY}"
 aws_key_path = "~/.ssh/bosh.pem"
 aws_key_name = "bosh"
 aws_region = "us-east-1"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,5 @@
-aws_access_key = "${AWS_ACCESS_KEY_ID}"
-aws_secret_key = "${AWS_SECRET_ACCESS_KEY}"
+aws_access_key = "XXXXXXXXXXXXXXXXXXXX"
+aws_secret_key = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 aws_key_path = "~/.ssh/bosh.pem"
 aws_key_name = "bosh"
 aws_region = "us-east-1"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,5 @@
-aws_access_key = "${AWS_ACCESS_KEY}"
-aws_secret_key = "${AWS_SECRET_KEY}"
+aws_access_key = $AWS_ACCESS_KEY
+aws_secret_key = $AWS_SECRET_KEY
 aws_key_path = "~/.ssh/bosh.pem"
 aws_key_name = "bosh"
 aws_region = "us-east-1"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,5 @@
-aws_access_key = "XXXXXXXXXXXXXX"
-aws_secret_key = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+aws_access_key = "F2j8zeb+vFAsHRZPArBIml12JOariFRXrGge88b2UpU0J128/No4VBvPyVSAEedjDOml/a8dE4ZKtZP09MRYk9a23a/t1TbW+IvYf3Ia0jvwBgbUtt8/TFd6n1aUHpP/+Oc/PlhklzHOGfm6ZT5F2lmyFrfvAcxnl3Ru+xghHGY="
+aws_secret_key = "euK9xBIMpCnD5r/5V76EJI2lCk5EbGhyUhFKFHOnMzXPSIEUbo7i7DW5oAJu5F0T/ynlhX68VUpUFJEz2QGs7CnqtOvHzl8763UFNisTbzCB7qXXQHIbLPKR+9lpxmeydL7o+3C5YIWk7hhRfQyxKaeLiWpXzOKCsJn8kT8EQY4="
 aws_key_path = "~/.ssh/bosh.pem"
 aws_key_name = "bosh"
 aws_region = "us-east-1"

--- a/test-fixtures/terraform.testplan
+++ b/test-fixtures/terraform.testplan
@@ -14,6 +14,7 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m    allocation_id:     "" => "<computed>"
     association_id:    "" => "<computed>"
     domain:            "" => "<computed>"
+    instance:          "" => "<computed>"
     network_interface: "" => "<computed>"
     private_ip:        "" => "<computed>"
     public_ip:         "" => "<computed>"
@@ -21,11 +22,12 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m
 [0m[32m+ aws_route_table.public
 [0m    route.#:                                    "" => "1"
-    route.2153853322.cidr_block:                "" => "0.0.0.0/0"
-    route.2153853322.gateway_id:                "" => "X"
-    route.2153853322.instance_id:               "" => ""
-    route.2153853322.network_interface_id:      "" => ""
-    route.2153853322.vpc_peering_connection_id: "" => ""
+    route.2586884343.cidr_block:                "" => "0.0.0.0/0"
+    route.2586884343.gateway_id:                "" => "X"
+    route.2586884343.instance_id:               "" => ""
+    route.2586884343.nat_gateway_id:            "" => ""
+    route.2586884343.network_interface_id:      "" => ""
+    route.2586884343.vpc_peering_connection_id: "" => ""
     vpc_id:                                     "" => "X"
 [0m
 [0m[32m+ aws_route_table_association.cfruntime-2a-private
@@ -113,15 +115,15 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
     ingress.3544538468.security_groups.#: "" => "0"
     ingress.3544538468.self:              "" => "1"
     ingress.3544538468.to_port:           "" => "65535"
-    name:                                 "" => "cf-0-X"
+    name:                                 "" => "cf--X"
     owner_id:                             "" => "<computed>"
     tags.#:                               "" => "1"
-    tags.Name:                            "" => "cf-0-X"
+    tags.Name:                            "" => "cf--X"
     vpc_id:                               "" => "X"
 [0m
 [0m[32m+ aws_subnet.cfruntime-2a
 [0m    availability_zone:       "" => "us-west-2a"
-    cidr_block:              "" => "10.10.03.0/24"
+    cidr_block:              "" => "10.10.3.0/24"
     map_public_ip_on_launch: "" => "0"
     tags.#:                  "" => "1"
     tags.Name:               "" => "cf1"
@@ -129,7 +131,7 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m
 [0m[32m+ aws_subnet.cfruntime-2b
 [0m    availability_zone:       "" => "us-west-2a"
-    cidr_block:              "" => "10.10.04.0/24"
+    cidr_block:              "" => "10.10.4.0/24"
     map_public_ip_on_launch: "" => "0"
     tags.#:                  "" => "1"
     tags.Name:               "" => "cf2"
@@ -137,7 +139,7 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m
 [0m[32m+ aws_subnet.docker
 [0m    availability_zone:       "" => "us-west-2a"
-    cidr_block:              "" => "10.10.05.0/24"
+    cidr_block:              "" => "10.10.5.0/24"
     map_public_ip_on_launch: "" => "0"
     tags.#:                  "" => "1"
     tags.Name:               "" => "docker"
@@ -145,7 +147,7 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m
 [0m[32m+ aws_subnet.lb
 [0m    availability_zone:       "" => "us-west-2a"
-    cidr_block:              "" => "10.10.02.0/24"
+    cidr_block:              "" => "10.10.2.0/24"
     map_public_ip_on_launch: "" => "0"
     tags.#:                  "" => "1"
     tags.Name:               "" => "lb"
@@ -153,10 +155,11 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m
 [0m[32m+ aws_subnet.logsearch
 [0m    availability_zone:       "" => "us-west-2a"
-    cidr_block:              "" => "10.10.07.0/24"
+    cidr_block:              "" => "10.10.7.0/24"
     map_public_ip_on_launch: "" => "0"
     tags.#:                  "" => "1"
     tags.Name:               "" => "logsearch"
     vpc_id:                  "" => "X"
 [0m
 [0m
+[0m[1mPlan:[0m 13 to add, 0 to change, 0 to destroy.[0m

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "network" {
 }
 
 variable "offset" {
-  default = "0"
+  default = ""
 }
 
 variable "aws_vpc_id" {}


### PR DESCRIPTION
This fixes a problem that's bubbled up to other repositories that depend on this and are trying to build using terraform on AWS.

Basically if the offset is set to 0, then it produces a CIDR range 10.0.04.0/24:

```
2016/05/06 14:18:20 [DEBUG] terraform-provider-aws: Action=CreateSubnet&AvailabilityZone=us-west-2b&CidrBlock=10.10.04.0%2F24&Version=2015-10-01&VpcId=vpc-13d87077
```

AWS returns a 500 for creating a subnet when it's a `04`.  But when running it without the offset on the command line it works.

```
aws ec2 create-subnet --availability-zone us-west-2b --vpc-id vpc-13d87077 --cidr-block "10.10.4.0/24"
```
